### PR TITLE
misc: improve unit test coverage

### DIFF
--- a/contracts/core/BaseVault.sol
+++ b/contracts/core/BaseVault.sol
@@ -296,7 +296,7 @@ contract BaseVault is ReentrancyGuard, Ownable, ERC20, Initializable {
     // This checks if there is a withdrawal
     require(withdrawalShares > 0, "Not initiated");
 
-    require(withdrawalRound < vaultState.round, "Round not closed");
+    require(withdrawalRound < vaultState.round, "Round in progress");
 
     // We leave the round number as non-zero to save on gas for subsequent writes
     withdrawals[msg.sender].shares = 0;

--- a/contracts/libraries/VaultLifecycle.sol
+++ b/contracts/libraries/VaultLifecycle.sol
@@ -100,6 +100,8 @@ library VaultLifecycle {
     // deposits and withdrawals, is positive. If it is negative, last week's
     // option expired ITM past breakeven, and the vault took a loss so we
     // do not collect performance fee for last week
+
+    // todo: update management fee to exclude profit?
     if (lockedBalanceSansPending > prevLockedAmount) {
       _performanceFeeInAsset = performanceFeePercent > 0
         ? lockedBalanceSansPending.sub(prevLockedAmount).mul(performanceFeePercent).div(100 * Vault.FEE_MULTIPLIER)

--- a/contracts/test/ShareMathTest.sol
+++ b/contracts/test/ShareMathTest.sol
@@ -6,11 +6,11 @@ import {ShareMath} from "../libraries/ShareMath.sol";
 import {Vault} from "../libraries/Vault.sol";
 
 /**
- * This is a tester contract where we expose all internal functions from ShareMath to external functions. 
- * Just so we can easily test them.  
+ * This is a tester contract where we expose all internal functions from ShareMath to external functions.
+ * Just so we can easily test them.
  */
 contract ShareMathTest {
-    function assetToShares(
+  function assetToShares(
     uint assetAmount,
     uint assetPerShare,
     uint decimals

--- a/contracts/test/ShareMathTest.sol
+++ b/contracts/test/ShareMathTest.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+pragma abicoder v2;
+
+import {ShareMath} from "../libraries/ShareMath.sol";
+import {Vault} from "../libraries/Vault.sol";
+
+/**
+ * This is a tester contract where we expose all internal functions from ShareMath to external functions. 
+ * Just so we can easily test them.  
+ */
+contract ShareMathTest {
+    function assetToShares(
+    uint assetAmount,
+    uint assetPerShare,
+    uint decimals
+  ) external pure returns (uint) {
+    return ShareMath.assetToShares(assetAmount, assetPerShare, decimals);
+  }
+
+  function sharesToAsset(
+    uint shares,
+    uint assetPerShare,
+    uint decimals
+  ) external pure returns (uint) {
+    return ShareMath.sharesToAsset(shares, assetPerShare, decimals);
+  }
+
+  /**
+   * @notice Returns the shares unredeemed by the user given their DepositReceipt
+   * @param depositReceipt is the user's deposit receipt
+   * @param currentRound is the `round` stored on the vault
+   * @param assetPerShare is the price in asset per share
+   * @param decimals is the number of decimals the asset/shares use
+   * @return unredeemedShares is the user's virtual balance of shares that are owed
+   */
+  function getSharesFromReceipt(
+    Vault.DepositReceipt memory depositReceipt,
+    uint currentRound,
+    uint assetPerShare,
+    uint decimals
+  ) external pure returns (uint unredeemedShares) {
+    return ShareMath.getSharesFromReceipt(depositReceipt, currentRound, assetPerShare, decimals);
+  }
+
+  function pricePerShare(
+    uint totalSupply,
+    uint totalBalance,
+    uint pendingAmount,
+    uint decimals
+  ) external pure returns (uint) {
+    return ShareMath.pricePerShare(totalSupply, totalBalance, pendingAmount, decimals);
+  }
+
+  function assertUint104(uint num) external pure {
+    return ShareMath.assertUint104(num);
+  }
+
+  function assertUint128(uint num) external pure {
+    return ShareMath.assertUint128(num);
+  }
+}

--- a/test/unit-tests/core/vault-shares.ts
+++ b/test/unit-tests/core/vault-shares.ts
@@ -150,6 +150,13 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
         const sharesToWithdraw = depositAmount
         await expect(vault.connect(depositor).redeem(sharesToWithdraw)).to.be.revertedWith('Exceeds available')
       })
+
+      it('should get 0 share if calling maxRedeem with no deposit Receipt', async() => {
+        const sharesBefore = await vault.balanceOf(anyone.address)
+        await vault.connect(anyone).maxRedeem()
+        const sharesAfter = await vault.balanceOf(anyone.address)
+        expect(sharesAfter).to.be.eq(sharesBefore)
+      })
   
       it('should get 0 share out by calling maxRedeem becuase depositor has no unreedemed shares', async() => {
         const sharesBefore = await vault.balanceOf(depositor.address)

--- a/test/unit-tests/core/vault-shares.ts
+++ b/test/unit-tests/core/vault-shares.ts
@@ -203,6 +203,9 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
     })
   
     describe('redeem shares', async() => {
+      it('should revert while redeeming 0 shares', async() => {
+        await expect(vault.connect(depositor).redeem(0)).to.be.revertedWith('!numShares')
+      })
       it('should has some share balance after rollover', async() => {
         const {heldByVault, heldByAccount} =  await vault.shareBalances(depositor.address)
         expect(heldByAccount).to.be.eq(0)
@@ -320,6 +323,10 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
       expect(round).to.be.eq(3)
     })
     describe('after rollover', async() => {
+      it('should revert when trying to initiateWithdraw again before completing queued withdraw', async() => {
+        const sharesToWithdraw = depositAmount
+        await expect(vault.connect(depositor).initiateWithdraw(sharesToWithdraw)).to.be.revertedWith('Existing withdraw')
+      })
       it('should be able to complete withdraw from previous rounds', async() => {
         const sethBalanceBefore = await seth.balanceOf(vault.address)
         await vault.connect(depositor).completeWithdraw()

--- a/test/unit-tests/core/vault-shares.ts
+++ b/test/unit-tests/core/vault-shares.ts
@@ -326,7 +326,7 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
         expect(vaultBalanceAfter.sub(vaultBalanceBefore)).to.be.eq(settlementPayout)
       })
       it('should revert if trying to completeWithdraw', async() => {
-        await expect(vault.connect(depositor).completeWithdraw()).to.be.revertedWith('Round not closed')
+        await expect(vault.connect(depositor).completeWithdraw()).to.be.revertedWith('Round in progress')
       })
       it('should rollover the vault to the next round', async() => {
         await vault.closeRound()

--- a/test/unit-tests/core/vault-shares.ts
+++ b/test/unit-tests/core/vault-shares.ts
@@ -132,6 +132,10 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
         expect(newReceipt.amount.sub(initReceipt.amount)).to.be.eq(depositAmount)
         expect(newReceipt.unredeemedShares).to.be.eq(initReceipt.unredeemedShares)
       })
+
+      it('should revert when using initiateWithdraw with shareNum = 0', async() => {
+        await expect(vault.connect(depositor).initiateWithdraw(0)).to.be.revertedWith('!numShares')
+      })
   
       it('should revert when using initiateWithdraw becuase user has no shares', async() => {
         const sharesToWithdraw = depositAmount

--- a/test/unit-tests/libraries/share-math.ts
+++ b/test/unit-tests/libraries/share-math.ts
@@ -1,0 +1,40 @@
+import { expect, util } from 'chai';
+import { ethers } from 'hardhat';
+import { ShareMathTest } from '../../../typechain';
+
+describe('Unit test: ShareMath Library', async () => {
+  let tester: ShareMathTest
+
+  before('deploy tester', async () => {
+    const ShareMathTestFactory = await ethers.getContractFactory('ShareMathTest');
+    tester = (await ShareMathTestFactory.deploy()) as ShareMathTest
+  });
+
+  describe('#assetToShares', async() => {
+    it('shoudl revert if share price is 0', async() => {
+      await expect(tester.assetToShares(0, 1, 0)).to.be.revertedWith('Invalid assetPerShare')
+    })
+  })
+  describe('#sharesToAsset', async() => {
+      await expect(tester.sharesToAsset(0, 1, 0)).to.be.revertedWith('Invalid assetPerShare')
+  })
+  describe('#getSharesFromReceipt', async() => {
+      
+  })
+  describe('#pricePerShare', async() => {
+      
+  })
+
+  describe('#assertUint104', async() => {
+    it('should revert if pass in number > uint104', async() => {
+      await expect(tester.assertUint104(ethers.constants.MaxInt256)).to.be.revertedWith('Overflow uint104')
+    })
+  })
+
+  describe('#assertUint128', async() => {
+    it('should revert if pass in number > uint128', async() => {
+      await expect(tester.assertUint128(ethers.constants.MaxInt256)).to.be.revertedWith('Overflow uint128')
+    })
+  })
+   
+}); 

--- a/test/unit-tests/libraries/share-math.ts
+++ b/test/unit-tests/libraries/share-math.ts
@@ -1,5 +1,6 @@
 import { expect, util } from 'chai';
 import { ethers } from 'hardhat';
+import { thomsonCrossSectionDependencies } from 'mathjs';
 import { ShareMathTest } from '../../../typechain';
 
 describe('Unit test: ShareMath Library', async () => {
@@ -16,15 +17,11 @@ describe('Unit test: ShareMath Library', async () => {
     })
   })
   describe('#sharesToAsset', async() => {
+    it('shoudl revert if share price is 0', async() => {
       await expect(tester.sharesToAsset(0, 1, 0)).to.be.revertedWith('Invalid assetPerShare')
+    })
   })
-  describe('#getSharesFromReceipt', async() => {
-      
-  })
-  describe('#pricePerShare', async() => {
-      
-  })
-
+  
   describe('#assertUint104', async() => {
     it('should revert if pass in number > uint104', async() => {
       await expect(tester.assertUint104(ethers.constants.MaxInt256)).to.be.revertedWith('Overflow uint104')

--- a/test/unit-tests/libraries/share-math.ts
+++ b/test/unit-tests/libraries/share-math.ts
@@ -1,6 +1,5 @@
-import { expect, util } from 'chai';
+import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { thomsonCrossSectionDependencies } from 'mathjs';
 import { ShareMathTest } from '../../../typechain';
 
 describe('Unit test: ShareMath Library', async () => {

--- a/test/unit-tests/utils/synthetixUtils.ts
+++ b/test/unit-tests/utils/synthetixUtils.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'hardhat';
 
-export const toBytes32 = (msg: string) => {
+export const toBytes32 = (msg: string): string => {
     return ethers.utils.formatBytes32String(msg);
 }


### PR DESCRIPTION
## This PR adds tests to make sure all branches are covered.

For SafeMath library, there're a few lines that's not reachable, so need to use a `SafeMathTest` contract to call those line directly. 

Another interesting edge case is if a user initiates a small withdraw amount, and after the round settles, the value of the shares  = 0, it should fail instead of trying to transfer amount 0.