### PR TITLE
feat: improve trading life cycle.

### DIFF
--- a/contracts/core/BaseVault.sol
+++ b/contracts/core/BaseVault.sol
@@ -375,24 +375,6 @@ contract BaseVault is ReentrancyGuard, Ownable, ERC20, Initializable {
    ***********************************************/
 
   /*
-   * @notice Helper function that helps to save gas for writing values into the roundPricePerShare map.
-   *         Writing `1` into the map makes subsequent writes warm, reducing the gas from 20k to 5k.
-   *         Having 1 initialized beforehand will not be an issue as long as we round down share calculations to 0.
-   * @param numRounds is the number of rounds to initialize in the map
-   */
-  // function initRounds(uint numRounds) external nonReentrant {
-  //   require(numRounds > 0, "!numRounds");
-
-  //   uint _round = vaultState.round;
-  //   for (uint i = 0; i < numRounds; i++) {
-  //     uint index = _round + i;
-  //     require(index >= _round, "Overflow");
-  //     require(roundPricePerShare[index] == 0, "Initialized"); // AVOID OVERWRITING ACTUAL VALUES
-  //     roundPricePerShare[index] = ShareMath.PLACEHOLDER_UINT;
-  //   }
-  // }
-
-  /*
    * @notice Helper function that performs most administrative tasks
    * such as setting next option, minting new shares, getting vault fees, etc.
    * @param lastQueuedWithdrawAmount is old queued withdraw amount
@@ -493,7 +475,7 @@ contract BaseVault is ReentrancyGuard, Ownable, ERC20, Initializable {
   function shareBalances(address account) public view returns (uint heldByAccount, uint heldByVault) {
     Vault.DepositReceipt memory depositReceipt = depositReceipts[account];
 
-    if (depositReceipt.round < ShareMath.PLACEHOLDER_UINT) {
+    if (depositReceipt.round == 0) {
       return (balanceOf(account), 0);
     }
 

--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -93,7 +93,7 @@ contract LyraVault is Ownable, BaseVault {
   /// @param listingIds an array of listingId that the vault traded with in the last round.
   function settle(uint[] memory listingIds) external {
     // eth call options are settled in eth
-    for(uint i = 0; i < listingIds.length; i++) {
+    for (uint i = 0; i < listingIds.length; i++) {
       optionMarket.settleOptions(listingIds[i], IOptionMarket.TradeType.SHORT_CALL);
     }
   }

--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -32,8 +32,8 @@ contract LyraVault is Ownable, BaseVault {
   /// @dev Synthetix currency key for sUSD
   bytes32 private immutable premiumCurrencyKey;
 
-  /// @dev Synthetix currency key for WETH
-  bytes32 private immutable wethCurrencyKey;
+  /// @dev Synthetix currency key for sETH
+  bytes32 private immutable sETHCurrencyKey;
 
   event StrategyUpdated(address strategy);
 
@@ -46,16 +46,16 @@ contract LyraVault is Ownable, BaseVault {
     string memory _tokenSymbol,
     Vault.VaultParams memory _vaultParams,
     bytes32 _premiumCurrencyKey,
-    bytes32 _wethCurrencyKey
+    bytes32 _sETHCurrencyKey
   ) BaseVault(_feeRecipient, 0, 0, _tokenName, _tokenSymbol, _vaultParams) {
     optionMarket = IOptionMarket(_optionMarket);
     synthetix = ISynthetix(_synthetix);
     IERC20(_vaultParams.asset).approve(_optionMarket, uint(-1));
 
     premiumCurrencyKey = _premiumCurrencyKey;
-    wethCurrencyKey = _wethCurrencyKey;
+    sETHCurrencyKey = _sETHCurrencyKey;
 
-    // allow synthetix to trade sUSD for WETH
+    // allow synthetix to trade sUSD for sETH
     IERC20(_susd).approve(_synthetix, uint(-1));
   }
 
@@ -85,8 +85,8 @@ contract LyraVault is Ownable, BaseVault {
 
     require(strategy.checkPostTrade(), "bad trade");
 
-    // exhcnage sUSD to WETH
-    synthetix.exchange(premiumCurrencyKey, realPremium, wethCurrencyKey);
+    // exhcnage sUSD to sETH
+    synthetix.exchange(premiumCurrencyKey, realPremium, sETHCurrencyKey);
   }
 
   /// @notice settle outstanding short positions.

--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -98,11 +98,12 @@ contract LyraVault is Ownable, BaseVault {
     }
   }
 
-  /// @dev close the next round, enable user to deposit
+  /// @dev close the current round, enable user to deposit for the next round
   function closeRound() external onlyOwner {
     vaultState.lastLockedAmount = vaultState.lockedAmount;
     vaultState.lockedAmountLeft = 0;
     vaultState.lockedAmount = 0;
+    vaultState.roundReady = now.add(DELAY);
   }
 
   /// @notice start the next round

--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -103,12 +103,12 @@ contract LyraVault is Ownable, BaseVault {
     vaultState.lastLockedAmount = vaultState.lockedAmount;
     vaultState.lockedAmountLeft = 0;
     vaultState.lockedAmount = 0;
-    vaultState.roundReady = now.add(DELAY);
+    vaultState.nextRoundReadyTimestamp = block.timestamp.add(Vault.ROUND_DELAY);
   }
 
   /// @notice start the next round
   function startNextRound() external {
-    // todo: cannot roll over anytime. This should be certain time after close round
+    require(block.timestamp > vaultState.nextRoundReadyTimestamp, "CD");
 
     (uint lockedBalance, uint queuedWithdrawAmount) = _rollToNextRound(uint(lastQueuedWithdrawAmount));
 

--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -90,20 +90,24 @@ contract LyraVault is Ownable, BaseVault {
 
   /// @notice settle outstanding short positions.
   /// @dev anyone can call the function to settle outstanding expired positions
-  function settle(uint listingId) external {
+  /// @param listingIds an array of listingId that the vault traded with in the last round.
+  function settle(uint[] memory listingIds) external {
     // eth call options are settled in eth
-    optionMarket.settleOptions(listingId, IOptionMarket.TradeType.SHORT_CALL);
+    for(uint i = 0; i < listingIds.length; i++) {
+      optionMarket.settleOptions(listingIds[i], IOptionMarket.TradeType.SHORT_CALL);
+    }
   }
 
+  /// @dev close the next round, enable user to deposit
   function closeRound() external onlyOwner {
     vaultState.lastLockedAmount = vaultState.lockedAmount;
     vaultState.lockedAmountLeft = 0;
     vaultState.lockedAmount = 0;
   }
 
-  /// @notice roll to next round
-  function rollToNextRound() external {
-    // todo: cannot roll over anytime. This should be done after settlement
+  /// @notice start the next round
+  function startNextRound() external {
+    // todo: cannot roll over anytime. This should be certain time after close round
 
     (uint lockedBalance, uint queuedWithdrawAmount) = _rollToNextRound(uint(lastQueuedWithdrawAmount));
 

--- a/contracts/libraries/ShareMath.sol
+++ b/contracts/libraries/ShareMath.sol
@@ -7,8 +7,6 @@ import {Vault} from "./Vault.sol";
 library ShareMath {
   using SafeMath for uint;
 
-  uint internal constant PLACEHOLDER_UINT = 1;
-
   function assetToShares(
     uint assetAmount,
     uint assetPerShare,
@@ -16,8 +14,7 @@ library ShareMath {
   ) internal pure returns (uint) {
     // If this throws, it means that vault's roundPricePerShare[currentRound] has not been set yet
     // which should never happen.
-    // Has to be larger than 1 because `1` is used in `initRoundPricePerShares` to prevent cold writes.
-    require(assetPerShare > PLACEHOLDER_UINT, "Invalid assetPerShare");
+    require(assetPerShare > 0, "Invalid assetPerShare");
 
     return assetAmount.mul(10**decimals).div(assetPerShare);
   }
@@ -29,8 +26,7 @@ library ShareMath {
   ) internal pure returns (uint) {
     // If this throws, it means that vault's roundPricePerShare[currentRound] has not been set yet
     // which should never happen.
-    // Has to be larger than 1 because `1` is used in `initRoundPricePerShares` to prevent cold writes.
-    require(assetPerShare > PLACEHOLDER_UINT, "Invalid assetPerShare");
+    require(assetPerShare > 0, "Invalid assetPerShare");
 
     return shares.mul(assetPerShare).div(10**decimals);
   }

--- a/contracts/libraries/Vault.sol
+++ b/contracts/libraries/Vault.sol
@@ -45,7 +45,7 @@ library Vault {
     // Amount locked for scheduled withdrawals;
     uint128 queuedWithdrawShares;
     // The timestamp next round will be ready to start
-    uint256 nextRoundReadyTimestamp;
+    uint nextRoundReadyTimestamp;
   }
 
   struct DepositReceipt {

--- a/contracts/libraries/Vault.sol
+++ b/contracts/libraries/Vault.sol
@@ -48,6 +48,8 @@ library Vault {
     uint128 queuedWithdrawShares;
     // The timestamp next round will be ready to start
     uint nextRoundReadyTimestamp;
+    // true if the current round is in progress, false if the round is idle
+    bool roundInProgress;
   }
 
   struct DepositReceipt {

--- a/contracts/libraries/Vault.sol
+++ b/contracts/libraries/Vault.sol
@@ -18,6 +18,8 @@ library Vault {
   // Percentage of funds allocated to options is 2 decimal places. 10 * 10**2 = 10%
   uint internal constant OPTION_ALLOCATION_MULTIPLIER = 10**2;
 
+  uint internal constant ROUND_DELAY = 1 days;
+
   struct VaultParams {
     // Token decimals for vault shares
     uint8 decimals;

--- a/contracts/libraries/Vault.sol
+++ b/contracts/libraries/Vault.sol
@@ -18,9 +18,6 @@ library Vault {
   // Percentage of funds allocated to options is 2 decimal places. 10 * 10**2 = 10%
   uint internal constant OPTION_ALLOCATION_MULTIPLIER = 10**2;
 
-  // Placeholder uint value to prevent cold writes
-  uint internal constant PLACEHOLDER_UINT = 1;
-
   struct VaultParams {
     // Token decimals for vault shares
     uint8 decimals;
@@ -47,6 +44,8 @@ library Vault {
     uint128 totalPending;
     // Amount locked for scheduled withdrawals;
     uint128 queuedWithdrawShares;
+    // The timestamp next round will be ready to start
+    uint256 nextRoundReadyTimestamp;
   }
 
   struct DepositReceipt {

--- a/test/unit-tests/core/vault-shares.ts
+++ b/test/unit-tests/core/vault-shares.ts
@@ -202,6 +202,10 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
       it('should be able to close the previous round', async() => {
         await vault.connect(owner).closeRound()
       })
+      it('stimulate time pass', async() => {
+        await ethers.provider.send("evm_increaseTime", [86400])
+        await ethers.provider.send("evm_mine", [])
+      })
       it('should be able to rollover the position', async() => {
         const roundBefore = await vault.vaultState()
         await vault.connect(owner).startNextRound()
@@ -336,6 +340,10 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
 
   describe('round 3: vault lose money', async() => {
     before('rollover to round 3', async() => {
+      
+      await ethers.provider.send("evm_increaseTime", [86400])
+      await ethers.provider.send("evm_mine", [])
+    
       await vault.connect(owner).startNextRound()
       const {round} = await vault.vaultState()
       expect(round).to.be.eq(3)
@@ -416,6 +424,10 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
 
   describe('round 4', async() => {
     before('rollover to round 4', async() => {
+
+      await ethers.provider.send("evm_increaseTime", [86400])
+      await ethers.provider.send("evm_mine", [])
+    
       await vault.connect(owner).startNextRound()
     })
     it('should revert when trying to complete the withdraw, because the collateral is 0', async() => {

--- a/test/unit-tests/core/vault-shares.ts
+++ b/test/unit-tests/core/vault-shares.ts
@@ -192,7 +192,7 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
         // set mocked asset only
         await mockedMarket.setMockCollateral(seth.address, parseEther('1'))
         await mockedMarket.setMockPremium(susd.address, 0)
-        await expect(vault.trade()).to.be.revertedWith('SafeMath: subtraction overflow')
+        await expect(vault.trade()).to.be.revertedWith('round closed')
       })
     });
   })

--- a/test/unit-tests/core/vault-shares.ts
+++ b/test/unit-tests/core/vault-shares.ts
@@ -204,7 +204,7 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
       })
       it('should be able to rollover the position', async() => {
         const roundBefore = await vault.vaultState()
-        await vault.connect(owner).rollToNextRound()
+        await vault.connect(owner).startNextRound()
         const roundAfter = await vault.vaultState()
         expect(roundBefore.round).to.be.eq(1)
         expect(roundAfter.round).to.be.eq(2)
@@ -321,7 +321,7 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
       it('should settle a specific listing and get back collateral (seth)', async() => {
         const vaultBalanceBefore = await seth.balanceOf(vault.address)
         const listingId = 0
-        await vault.settle(listingId)
+        await vault.settle([listingId])
         const vaultBalanceAfter = await seth.balanceOf(vault.address)
         expect(vaultBalanceAfter.sub(vaultBalanceBefore)).to.be.eq(settlementPayout)
       })
@@ -336,7 +336,7 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
 
   describe('round 3: vault lose money', async() => {
     before('rollover to round 3', async() => {
-      await vault.connect(owner).rollToNextRound()
+      await vault.connect(owner).startNextRound()
       const {round} = await vault.vaultState()
       expect(round).to.be.eq(3)
     })
@@ -404,7 +404,7 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
       it('should settle a specific listing and get back collateral (seth)', async() => {
         const vaultBalanceBefore = await seth.balanceOf(vault.address)
         const listingId = 0
-        await vault.settle(listingId)
+        await vault.settle([listingId])
         const vaultBalanceAfter = await seth.balanceOf(vault.address)
         expect(vaultBalanceAfter.sub(vaultBalanceBefore)).to.be.eq(settlementPayout)
       })
@@ -416,7 +416,7 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
 
   describe('round 4', async() => {
     before('rollover to round 4', async() => {
-      await vault.connect(owner).rollToNextRound()
+      await vault.connect(owner).startNextRound()
     })
     it('should revert when trying to complete the withdraw, because the collateral is 0', async() => {
       await expect(vault.connect(shrimp).completeWithdraw()).to.be.revertedWith('!withdrawAmount')

--- a/test/unit-tests/core/vault.ts
+++ b/test/unit-tests/core/vault.ts
@@ -215,6 +215,10 @@ describe('Unit test: Basic LyraVault flow', async () => {
       await vault.connect(owner).closeRound()
     })
     it('should be able to rollover the position', async() => {
+      
+      await ethers.provider.send("evm_increaseTime", [86400])
+      await ethers.provider.send("evm_mine", [])
+      
       const roundBefore = await vault.vaultState()
       await vault.connect(owner).startNextRound()
       const roundAfter = await vault.vaultState()
@@ -284,11 +288,22 @@ describe('Unit test: Basic LyraVault flow', async () => {
       await ethers.provider.send("evm_increaseTime", [86400*7])
       await ethers.provider.send("evm_mine", [])
     })
-    it('should rollover the vault to the next round, and pay the fee recpient fees', async() => {
+    
+    it('should close the current round', async() => {
+      await vault.closeRound()
+    })
+
+    it('should revert if trying to start the next round within 24 hours from close', async() => {
+      await expect(vault.startNextRound()).to.be.revertedWith("CD")
+    })
+
+    it('should roll into the next round and pay the fee recpient fees', async() => {
+      await ethers.provider.send("evm_increaseTime", [86400])
+      await ethers.provider.send("evm_mine", [])
+      
       const vaultStateBefore = await vault.vaultState()
       const recipientBalanceBefore = await seth.balanceOf(feeRecipient.address)
 
-      await vault.closeRound()
       await vault.startNextRound()
 
       const vaultStateAfter = await vault.vaultState()

--- a/test/unit-tests/core/vault.ts
+++ b/test/unit-tests/core/vault.ts
@@ -205,7 +205,7 @@ describe('Unit test: Basic LyraVault flow', async () => {
       await mockedMarket.setMockCollateral(seth.address, parseEther('1'))
       await mockedMarket.setMockPremium(susd.address, 0)
 
-      await expect(vault.trade()).to.be.revertedWith('SafeMath: subtraction overflow')
+      await expect(vault.trade()).to.be.revertedWith('round closed')
     })
   });
 
@@ -288,9 +288,17 @@ describe('Unit test: Basic LyraVault flow', async () => {
       await ethers.provider.send("evm_increaseTime", [86400*7])
       await ethers.provider.send("evm_mine", [])
     })
+
+    it('should revert if trying to start the next round without closing the round', async() => {
+      await expect(vault.startNextRound()).to.be.revertedWith("round opened")
+    })
     
     it('should close the current round', async() => {
       await vault.closeRound()
+    })
+
+    it('should revert if trying to trade right now', async() => {
+      await expect(vault.trade()).to.be.revertedWith('round closed')
     })
 
     it('should revert if trying to start the next round within 24 hours from close', async() => {

--- a/test/unit-tests/core/vault.ts
+++ b/test/unit-tests/core/vault.ts
@@ -216,7 +216,7 @@ describe('Unit test: Basic LyraVault flow', async () => {
     })
     it('should be able to rollover the position', async() => {
       const roundBefore = await vault.vaultState()
-      await vault.connect(owner).rollToNextRound()
+      await vault.connect(owner).startNextRound()
       const roundAfter = await vault.vaultState()
       expect(roundBefore.round).to.be.eq(1)
       expect(roundAfter.round).to.be.eq(2)
@@ -273,7 +273,7 @@ describe('Unit test: Basic LyraVault flow', async () => {
     it('should settle a specific listing and get back collateral (seth)', async() => {
       const vaultBalanceBefore = await seth.balanceOf(vault.address)
       const listingId = 0
-      await vault.settle(listingId)
+      await vault.settle([listingId])
       const vaultBalanceAfter = await seth.balanceOf(vault.address)
       expect(vaultBalanceAfter.sub(vaultBalanceBefore)).to.be.eq(settlementPayout)
     })
@@ -289,7 +289,7 @@ describe('Unit test: Basic LyraVault flow', async () => {
       const recipientBalanceBefore = await seth.balanceOf(feeRecipient.address)
 
       await vault.closeRound()
-      await vault.rollToNextRound()
+      await vault.startNextRound()
 
       const vaultStateAfter = await vault.vaultState()
 

--- a/test/unit-tests/libraries/share-math.ts
+++ b/test/unit-tests/libraries/share-math.ts
@@ -12,12 +12,12 @@ describe('Unit test: ShareMath Library', async () => {
 
   describe('#assetToShares', async() => {
     it('shoudl revert if share price is 0', async() => {
-      await expect(tester.assetToShares(0, 1, 0)).to.be.revertedWith('Invalid assetPerShare')
+      await expect(tester.assetToShares(0, 0, 0)).to.be.revertedWith('Invalid assetPerShare')
     })
   })
   describe('#sharesToAsset', async() => {
     it('shoudl revert if share price is 0', async() => {
-      await expect(tester.sharesToAsset(0, 1, 0)).to.be.revertedWith('Invalid assetPerShare')
+      await expect(tester.sharesToAsset(0, 0, 0)).to.be.revertedWith('Invalid assetPerShare')
     })
   })
   


### PR DESCRIPTION
This closes couple of issues that are all related:
1. rename `rollToNextRound` to `startNextRound`
2. enforce `closeRound` to be called before calling `startNextRound` (#15 )
3. it has to have a 24 hour delay between rounds, so user can single withdraw if the next round is malicious
4. make settlement more efficient by accepting list of listingIds (#9) 

## Misc cleanups
* removed  `ShareMath.PLACEHOLDER_UINT`