### PR TITLE
feat: fix management fee fixed with 1 week duration

### DIFF
--- a/contracts/core/BaseVault.sol
+++ b/contracts/core/BaseVault.sol
@@ -101,7 +101,7 @@ contract BaseVault is ReentrancyGuard, Ownable, ERC20, Initializable {
     Vault.VaultParams memory _vaultParams
   ) ERC20(_tokenName, _tokenSymbol) {
     feeRecipient = _feeRecipient;
-    uint _roundPerYear = uint256(365 days).mul(Vault.FEE_MULTIPLIER).div(_roundDuration);
+    uint _roundPerYear = uint(365 days).mul(Vault.FEE_MULTIPLIER).div(_roundDuration);
     roundPerYear = _roundPerYear;
     vaultParams = _vaultParams;
 

--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -42,12 +42,13 @@ contract LyraVault is Ownable, BaseVault {
     address _susd,
     address _feeRecipient,
     address _synthetix,
+    uint _roundDuration,
     string memory _tokenName,
     string memory _tokenSymbol,
     Vault.VaultParams memory _vaultParams,
     bytes32 _premiumCurrencyKey,
     bytes32 _sETHCurrencyKey
-  ) BaseVault(_feeRecipient, 0, 0, _tokenName, _tokenSymbol, _vaultParams) {
+  ) BaseVault(_feeRecipient,_roundDuration, _tokenName, _tokenSymbol, _vaultParams) {
     optionMarket = IOptionMarket(_optionMarket);
     synthetix = ISynthetix(_synthetix);
     IERC20(_vaultParams.asset).approve(_optionMarket, uint(-1));

--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -48,7 +48,7 @@ contract LyraVault is Ownable, BaseVault {
     Vault.VaultParams memory _vaultParams,
     bytes32 _premiumCurrencyKey,
     bytes32 _sETHCurrencyKey
-  ) BaseVault(_feeRecipient,_roundDuration, _tokenName, _tokenSymbol, _vaultParams) {
+  ) BaseVault(_feeRecipient, _roundDuration, _tokenName, _tokenSymbol, _vaultParams) {
     optionMarket = IOptionMarket(_optionMarket);
     synthetix = ISynthetix(_synthetix);
     IERC20(_vaultParams.asset).approve(_optionMarket, uint(-1));

--- a/contracts/libraries/Vault.sol
+++ b/contracts/libraries/Vault.sol
@@ -9,15 +9,6 @@ library Vault {
   // Fees are 6-decimal places. For example: 20 * 10**6 = 20%
   uint internal constant FEE_MULTIPLIER = 10**6;
 
-  // Premium discount has 1-decimal place. For example: 80 * 10**1 = 80%. Which represents a 20% discount.
-  uint internal constant PREMIUM_DISCOUNT_MULTIPLIER = 10;
-
-  // Otokens have 8 decimal places.
-  uint internal constant OTOKEN_DECIMALS = 8;
-
-  // Percentage of funds allocated to options is 2 decimal places. 10 * 10**2 = 10%
-  uint internal constant OPTION_ALLOCATION_MULTIPLIER = 10**2;
-
   uint internal constant ROUND_DELAY = 1 days;
 
   struct VaultParams {

--- a/test/unit-tests/core/vault-shares.ts
+++ b/test/unit-tests/core/vault-shares.ts
@@ -25,6 +25,8 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
   let depositor: SignerWithAddress
   let shrimp: SignerWithAddress // user with dust deposit
 
+  const roundDuration = 7 * 86400
+
   // fix deposit amount at 1 eth
   const depositAmount = parseEther('1')
 
@@ -73,6 +75,7 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
       susd.address,
       owner.address, // feeRecipient,
       mockedSynthetix.address,
+      roundDuration,
       "LyraVault Share",
       "Lyra VS",
       {
@@ -313,7 +316,7 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
       // assume option expires OTM, settlement will return the origianl collateral amount
       const settlementPayout = parseEther('1')
       before('simulate time pass', async() => {
-        await ethers.provider.send("evm_increaseTime", [86400*7])
+        await ethers.provider.send("evm_increaseTime", [roundDuration])
         await ethers.provider.send("evm_mine", [])
       })
       before('set mock settle data', async() => {
@@ -400,7 +403,7 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
       // assume option expires ITM, only get 40% of the collateral out!
       const settlementPayout = parseEther('0.4')
       before('simulate time pass', async() => {
-        await ethers.provider.send("evm_increaseTime", [86400*7])
+        await ethers.provider.send("evm_increaseTime", [roundDuration])
         await ethers.provider.send("evm_mine", [])
       })
       before('set mock settle data', async() => {

--- a/test/unit-tests/core/vault.ts
+++ b/test/unit-tests/core/vault.ts
@@ -3,9 +3,11 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { LyraVault, MockOptionMarket, MockStrategy, MockSynthetix, MockERC20 } from '../../../typechain';
-import { FEE_MULTIPLIER, WEEKS_PER_YEAR } from '../utils/constants';
+import { FEE_MULTIPLIER } from '../utils/constants';
 import { BigNumber } from 'ethers'
 import { toBytes32 } from '../utils/synthetixUtils';
+
+const roundDuration = 86400 * 7
 
 describe('Unit test: Basic LyraVault flow', async () => {
   // contract instances
@@ -91,6 +93,7 @@ describe('Unit test: Basic LyraVault flow', async () => {
         susd.address,
         owner.address, // feeRecipient,
         mockedSynthetix.address,
+        86400 * 7,
         "LyraVault Share",
         "Lyra VS",
         {
@@ -126,7 +129,7 @@ describe('Unit test: Basic LyraVault flow', async () => {
       await vault.connect(owner).setManagementFee(managementFee)
 
       const fee = await vault.managementFee()
-      const weeklyFee = BigNumber.from(managementFee).mul(FEE_MULTIPLIER).div(WEEKS_PER_YEAR)
+      const weeklyFee = BigNumber.from(managementFee).mul(7).div(365)
       expect(weeklyFee).to.be.eq(fee);
     })
     it('should revert when trying to set a mangement fee that\'s too high', async() => {

--- a/test/unit-tests/core/vault.ts
+++ b/test/unit-tests/core/vault.ts
@@ -7,8 +7,6 @@ import { FEE_MULTIPLIER } from '../utils/constants';
 import { BigNumber } from 'ethers'
 import { toBytes32 } from '../utils/synthetixUtils';
 
-const roundDuration = 86400 * 7
-
 describe('Unit test: Basic LyraVault flow', async () => {
   // contract instances
   let vault: LyraVault;

--- a/test/unit-tests/utils/constants.ts
+++ b/test/unit-tests/utils/constants.ts
@@ -1,3 +1,3 @@
 export const FEE_MULTIPLIER = 1e6
 
-export const WEEKS_PER_YEAR = 52142857
+export const SEC_IN_YEAR = 31540000


### PR DESCRIPTION
TLDR: Make management fee depends on round duration.
For example, if round duration is 2 weeks, bi-weekly management fee rate will be set to `fee * 14 / 365`.